### PR TITLE
fix: TimeTableView에서 시작기한에서 부터 마감기한 전까지만 슬롯 선택할 수 있도록 수정

### DIFF
--- a/SlotIn/Views/Home/TimeTableView.swift
+++ b/SlotIn/Views/Home/TimeTableView.swift
@@ -191,7 +191,11 @@ struct TimeTableView: View {
   }
   
   var model: TimeTableModel {
-      TimeTableModel(startDate: event.startDate, endDate: event.endDate)
+      guard let start = event.startDate, let end = event.endDate else {
+                // fallback: 현재 시간을 기준으로 임시 모델 리턴
+                return TimeTableModel(startDate: Date(), endDate: Date().addingTimeInterval(3600))
+            }
+            return TimeTableModel(startDate: start, endDate: end)
   }
   
   var requiredSlotCount: Int {
@@ -210,7 +214,7 @@ struct TimeTableView: View {
     let key = "\(dayIndex)-\(hour)"
     let date = Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: weekDates[dayIndex])!
     
-    let isAvailable = !hasEvent(at: date)
+    let isAvailable = !hasEvent(at: date) && !isOverDate(at: date)
     let isSelected = selectedSlots.contains(key)
     
     Button(action: {
@@ -292,6 +296,13 @@ struct TimeTableView: View {
     }
     return false
   }
+    
+    private func isOverDate(at date: Date) -> Bool {
+        if startTime <= date && date <= endTime {
+            return false
+      }
+      return true
+    }
 }
  
 #Preview {


### PR DESCRIPTION
## 📌 PR 내용 요약
- 간단한 작업 요약을 작성해주세요.
TimeTableView에서 시작기한에서 부터 마감기한 전까지만 슬롯 선택할 수 있도록 수정

## ✅ 작업 내용
- [x] 함수추가해서 기간외 슬롯 설정 불가능하게 변경

## 🔍 리뷰어 참고 사항
- 시작기간과 마감기간의 시간 데이터를 변경해줘야한다.